### PR TITLE
Fix to Codeserver, which disconnects frequently on Kubernetes and slurm mode didnt work

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -138,7 +138,7 @@ script:
     - "--ntasks"
     - "1"
     - "--cpus-per-task"
-    - "<%= num_cores %>"
+    - "<%= cores %>"
     - "--mem"
-    - "<%= num_mem %>G"
+    - "<%= memory %>G"
 <%- end -%>

--- a/template/after.sh.erb
+++ b/template/after.sh.erb
@@ -1,3 +1,5 @@
+<%- if context.cluster != "my-k8s-cluster" -%>
+
 # Wait for the Code Server to start
 echo "$(date): Waiting for Code Server to open port ${port}..."
 
@@ -10,3 +12,4 @@ fi
 
 sleep 2
 
+<%- end -%>


### PR DESCRIPTION
Two fixes to codeserver/VSCode on Ondemand

1. Kahu's fix to prevent Codeserver from disconnecting during a kubernetes session.
2. fix to submit.yml.erb to allow codeserver to work on Slurm.
